### PR TITLE
Consistency and grammar fixes; some rewording.

### DIFF
--- a/guide/accounts.rst
+++ b/guide/accounts.rst
@@ -5,37 +5,37 @@ We use a few websites to manage our code and bugs, and while it is possible to
 get by without signing up for these sites, it's *strongly* recommended that
 you create accounts on these websites.
 
-Github
+GitHub
 ------
 
-Many A-team projects are hosted on Github_. Github provides hosting for our
-source code, as well as tools we use for collaboration and code review. Github
-is based on git_, a distributed version control system that lets us track the
+Many A-Team projects are hosted on GitHub_. GitHub provides hosting for our
+source code, as well as tools we use for collaboration and code review. GitHub
+is based on Git_, a distributed version control system that lets us track the
 changes we make to our code.
 
-Once you've created a Github account, you can check out the `Github help site`_
-for guides on the basics of using git and Github.
+Once you've created a GitHub account, you can check out the `GitHub help site`_
+for guides on the basics of using Git and GitHub.
 
 .. seealso::
 
-   `Mozilla on Github <https://github.com/mozilla/>`_
-      Mozilla's organization account on Github.
+   `Mozilla on GitHub <https://github.com/mozilla/>`_
+      Mozilla's organization account on GitHub.
 
-.. _Github: https://github.com/
-.. _git: http://git-scm.com/
-.. _Github help site: https://help.github.com/
+.. _GitHub: https://github.com/
+.. _Git: http://git-scm.com/
+.. _GitHub help site: https://help.github.com/
 
 
 Mercurial and Mozilla-Central
 -----------------------------
 
 Much of our other build & test code lives inside `mozilla-central`_,
-a `mercurial`_ repository which also contains the source code to Firefox.
+a `Mercurial`_ repository which also contains the source code to Firefox.
 
 To be able to commit to this repository directly, you will need to
-sign a contributor's and be vouched for by a module owner. You
+sign a contributor's agreement and be vouched for by a module owner. You
 probably don't need to worry about this initially: just clone the
-repository manually, test your changes locally, and let other people
+repository, test your changes locally, and let other people
 push your patches for you.
 
 If you find that you're working on a lot of stuff within this
@@ -43,7 +43,7 @@ code base, you'll want to apply for `committer access`_ so you can push
 code to try_ or an integration branch like mozilla-inbound.
 
 .. _mozilla-central: https://developer.mozilla.org/en-US/docs/mozilla-central
-.. _mercurial: http://mercurial.selenic.com
+.. _Mercurial: http://mercurial.selenic.com
 .. _`committer access`: https://www.mozilla.org/en-US/about/governance/policies/commit/
 .. _try: https://wiki.mozilla.org/Build:TryServer
 
@@ -51,8 +51,8 @@ Bugzilla
 --------
 
 Bugzilla_ is the issue-tracking system that the entire Mozilla Project uses.
-The vast majority of A-team projects use Bugzilla to keep track of any planned
-changes or bugs with our websites.
+The vast majority of A-Team projects use Bugzilla to keep track of any planned
+changes to or bugs in our projects.
 
 As a new contributor, Bugzilla is a useful tool for finding known issues that
 you can help fix or finding planned work you want to take on. In order to
@@ -64,7 +64,7 @@ After you've been using Bugzilla for a while as a community member,
 it's worthwhile applying for expanded permissions. The editbugs
 permission allows you to assign bugs to yourself and resolve them, for
 example. See the `Bugzilla Permissions Page`_ for details. Note that
-new employees get this permission automatically, no need to ask for it.
+new employees get this permission automatically; there's no need to ask for it.
 
 .. note:: It's highly recommended to add your IRC nickname to your real name
    within Bugzilla to make it easy for others to auto-complete your name.

--- a/guide/ateam.rst
+++ b/guide/ateam.rst
@@ -14,7 +14,7 @@ There's two main channels of communication for the group:
 - The `tools@lists.mozilla.org mailing list
   <https://www.mozilla.org/about/forums/#tools>`_.
 
-If you ever have any question, regardless of how difficult it is, you can share
+If you ever have a question, regardless of how difficult it is, you can share
 it on those channels and someone should help you out. *Don't be afraid to ask
 questions!* You're trying to help us, so it's only fair that we try to help you
 in return.
@@ -28,5 +28,5 @@ finding your way around.
 
 If you're a new employee, your mentor may be your manager, or it may be a
 coworker. If you're a volunteer, ask someone who works on the project you want
-to contribute to, and if they cannot mentor you themselves, they should be able
+to contribute to; if they cannot mentor you themselves, they should be able
 to direct you to someone who can.

--- a/guide/development_process.rst
+++ b/guide/development_process.rst
@@ -2,7 +2,7 @@ Development Process
 ===================
 
 While the details vary, there is a general framework for the development
-process at Mozilla which describes how a change goes from an idea in someone's
+process at Mozilla, which describes how a change goes from an idea in someone's
 head to deployed code. This document attempts to describe that process.
 
 Filing a Bug
@@ -19,9 +19,9 @@ choice for the project. A well-written bug includes:
   issue.
 
 Depending on the project, the bug may be triaged and assigned a priority and/or
-milestone, or it may be added to another system for tracking work, such as trello_.
+milestone, or it may be added to another system for tracking work, such as Trello_.
 
-.. _trello: http://trello.com
+.. _Trello: http://trello.com
 
 Working on the Bug
 ------------------
@@ -43,20 +43,20 @@ The process of fixing a bug involves:
   updating your changes in response to the review.
 - Merging your feature branch back into the main branch used for development.
 
-Git and Github
+Git and GitHub
 ^^^^^^^^^^^^^^
 
-For projects using Git and Github, the process can be explained in more detail:
+For projects using Git and GitHub, the process can be explained in more detail:
 
-- On Github, ensure you have `forked the repository`_ for your project to your
+- On GitHub, ensure you have `forked the repository`_ for your project to your
   own account and have added it as a `remote`_ to your repository.
 - Identify the main development branch for your project. This is usually the
   ``master`` branch.
-- Make sure the current branch is the development branch and create a new
+- Make sure the current branch is the development branch, and create a new
   branch off of it for your feature.
 - Once your work is committed and ready for review, `push the branch`_ to your
-  fork on Github and `submit a pull request`_.
-- If the project uses bugzilla for issue tracking, `create an attachment
+  fork on GitHub and `submit a pull request`_.
+- If the project uses Bugzilla for issue tracking, `create an attachment
   to your issue's bug pointing at the pull request`_. Otherwise, if
   you know who should review your change, add a comment to your pull request
   with their ``@Username`` in it and ask for a review.
@@ -64,10 +64,10 @@ For projects using Git and Github, the process can be explained in more detail:
 .. seealso::
 
    :doc:`/reference/glossary`
-      A glossary of specialized terms used within the A-team, including some
+      A glossary of specialized terms used within the A-Team, including some
       abbreviations used for code review, such as ``r?``, ``r+``, and ``r-``.
 
-   `Github Flow <https://guides.github.com/introduction/flow/>`_
+   `GitHub Flow <https://guides.github.com/introduction/flow/>`_
       A process for branching, reviewing, and merging code that is very similar
       to the process above.
 
@@ -81,7 +81,7 @@ For projects using Git and Github, the process can be explained in more detail:
 Mercurial
 ^^^^^^^^^
 
-For projects using Mercurial (for example, talos_ or mozbase_) the
+For projects using Mercurial (for example, Talos_ or Mozbase_) the
 process looks like this:
 
 - Check out the source code of the project you want to contribute to
@@ -90,8 +90,8 @@ process looks like this:
   alternatively, use `mercurial bookmarks`_ to do the same thing).
 - Finish your work and commit the changes, then `submit them as a patch`_.
 
-.. _talos: https://wiki.mozilla.org/Buildbot/Talos
-.. _mozbase: https://wiki.mozilla.org/Auto-tools/Projects/MozBase
+.. _Talos: https://wiki.mozilla.org/Buildbot/Talos
+.. _Mozbase: https://wiki.mozilla.org/Auto-tools/Projects/MozBase
 .. _mozilla-central: https://developer.mozilla.org/en-US/docs/mozilla-central
 .. _mercurial queue: https://developer.mozilla.org/en-US/docs/Mercurial_Queues
 .. _mercurial bookmarks: http://mercurial.selenic.com/wiki/NamedBranches
@@ -118,7 +118,7 @@ your first contribution to Mozilla! Once you've submitted your work and gotten
 it merged, it's time to celebrate: you've earned it!
 
 As you continue to contribute, you may want to check out the
-:doc:`/reference/index` to find generally-useful information for contributors
+:doc:`/reference/index` to find generally useful information for contributors
 of all levels.
 
 Good luck!

--- a/guide/index.rst
+++ b/guide/index.rst
@@ -4,9 +4,9 @@ New Contributor Guide
 First things first: Welcome to Mozilla! We're glad to have you here, whether
 you're considering volunteering as a contributor or are employed by Mozilla.
 
-Our goal here is to get you up and running for contributing as an
+Our goal here is to get you up and running to contribute as an
 automation developer. This guide attempts to be generic enough to be
-useful to most ateam projects, but some details (especially around
+useful to most A-Team projects, but some details (especially around
 software you need installed) may vary among projects.
 
 Let's get started!

--- a/guide/projects.rst
+++ b/guide/projects.rst
@@ -12,7 +12,7 @@ Getting set up
 
 Once you've identified the project you want to work on, you should set up a
 development instance of it locally. All projects have (or should have) a README
-file in their source tree that either describes this or links to
+file in their source tree that either describes this process or links to
 documentation that does.
 
 Find a mentor
@@ -29,7 +29,7 @@ How to contribute
 -----------------
 
 Once you're set up to work on a project, you'll have to find a task to work on
-and get to work! Each project should have some information on where their tasks
+and get coding! Each project should have some information on where their tasks
 are tracked, generally on Bugzilla_.
 
 .. _Bugzilla: http://bugzilla.mozilla.org

--- a/guide/software.rst
+++ b/guide/software.rst
@@ -17,7 +17,7 @@ development environments because the tooling is much more
 comprehensive. If you are a Windows user, you may want to use a
 program like `VirtualBox`_ to create a virtual machine running a
 Linux-based operating system. The rest of this guide assumes you are
-using an OS X or Linux-based operating system.
+using OS X or a Linux-based operating system.
 
 If you are running Mac OS X, most of the software mentioned here can be
 installed using the `Homebrew`_ package manager.
@@ -36,30 +36,30 @@ same time and merge their changes together at the end.
 .. seealso::
 
    `help.github.com <https://help.github.com/>`_
-      A great guide to getting start with Git and Github, which hosts most of
-      our git repositories.
+      A great guide to getting start with Git and GitHub, which hosts most of
+      our Git repositories.
 
-   `Github for Windows <https://windows.github.com/>`_
-      A Windows program for interacting with Github as an alternative to using
-      git in a terminal. Useful if you are not used to using a terminal yet.
+   `GitHub for Windows <https://windows.github.com/>`_
+      A Windows program for interacting with GitHub as an alternative to using
+      Git in a terminal. Useful if you are not used to using a terminal yet.
 
-   `Github for Mac <https://mac.github.com/>`_
-      A Mac OS X program for interacting with Github as an alternative to using
-      git in a terminal. Useful if you are not used to using a terminal yet.
+   `GitHub for Mac <https://mac.github.com/>`_
+      A Mac OS X program for interacting with GitHub as an alternative to using
+      Git in a terminal. Useful if you are not used to using a terminal yet.
 
 .. _Git: http://git-scm.com/
 
 Mercurial
 ---------
 
-Mercurial_ is a version control system, similar to git. We use it to
+Mercurial_ is a version control system similar to Git. We use it to
 track the source code to Firefox itself, as well as much of the
 automated test infrastructure around it (mochitest, reftest, etc.).
 
 .. seealso::
 
    `Mozilla's Guide to Mercurial <https://developer.mozilla.org/en-US/docs/Mercurial>`_
-     The MDN page on Mercurial, contains some useful links for getting
+     The MDN page on Mercurial contains some useful links for getting
      started.
 
 .. _Mercurial: http://mercurial.selenic.com
@@ -67,12 +67,13 @@ automated test infrastructure around it (mochitest, reftest, etc.).
 Python
 ------
 
-Python_ is a programming language that many of our websites use for their
-backend code. Many of our Python-based sites are implemented using Django_,
-a Python-based framework for making websites.
+Python_ is a programming language that we use in many of our tools and
+automation frameworks. Our bigger web-based tools are often implemented
+using Django_, a Python-based framework for making websites, but we also
+use other web frameworks, such as Flask_, for smaller apps.
 
-Most of our Python-based sites are developed to run under Python 2, and most
-of our servers run the sites on Python 2.
+Most of our Python-based projects are developed to run under Python 2, and most
+of our servers run web apps using Python 2.
 
 .. seealso::
 
@@ -82,3 +83,4 @@ of our servers run the sites on Python 2.
 
 .. _Python: https://www.python.org/
 .. _Django: https://www.djangoproject.com/
+.. _Flask: http://flask.pocoo.org/

--- a/index.rst
+++ b/index.rst
@@ -1,18 +1,17 @@
 A-Team Bootcamp
 ===============
 
-Hello! Welcome to the `Mozilla Automation & Tools`_ (a.k.a. the
-"ateam") Bootcamp, an informal guide to how test automation
-development is done at Mozilla.
+Hello! Welcome to the `Mozilla Automation & Tools`_  Bootcamp, an informal
+guide to how test-automation development is done at Mozilla.
 
 This document is based off of the excellent `Mozilla WebDev bootcamp`_.
 
 .. _`Mozilla Automation & Tools`: https://wiki.mozilla.org/Auto-tools
 .. _`Mozilla WebDev bootcamp`: http://mozweb.readthedocs.org
 
-If you're a new contributor / new employee, you can start out by reading the
+If you're a new contributor or new employee, you can start out by reading the
 :doc:`guide/index`. If you're already a contributor, you can find
-generally-useful info, such as style guides, in the :doc:`reference/index`.
+generally useful info, such as style guides, in the :doc:`reference/index`.
 
 .. toctree::
    :maxdepth: 2

--- a/reference/git_github.rst
+++ b/reference/git_github.rst
@@ -1,12 +1,12 @@
-Git and Github
+Git and GitHub
 ==============
 
-This document describes some best practices for using Git and Github.
+This document describes some best practices for using Git and GitHub.
 
 Commit Messages
 ---------------
 
-See `Tim Pope's blog post on git commit messages
+See `Tim Pope's blog post on Git commit messages
 <http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html>`_.
 
 Rebasing Commits
@@ -53,8 +53,8 @@ the pull request as the content. This will cause Bugzilla to link to the pull
 request and allow you to set the review bit on the attachment to track the
 state of the review in Bugzilla.
 
-Owners and the Mozilla Github Organization
+Owners and the Mozilla GitHub Organization
 ------------------------------------------
-See the `Github page on wiki.mozilla.org <https://wiki.mozilla.org/Github>`_
-for information on the Mozilla organization on Github or anything that requires
+See the `GitHub page on wiki.mozilla.org <https://wiki.mozilla.org/Github>`_
+for information on the Mozilla organization on GitHub or anything that requires
 owner access for the organization.

--- a/reference/glossary.rst
+++ b/reference/glossary.rst
@@ -9,8 +9,8 @@ define those terms.
 
    pull request
    PR
-      A term for a request on Github to merge some changes into a codebase.
-      Pull requests are the primary place where code review happens for Github
+      A term for a request on GitHub to merge some changes into a codebase.
+      Pull requests are the primary place where code review happens for GitHub
       projects.
 
    r?

--- a/reference/js-style.rst
+++ b/reference/js-style.rst
@@ -89,12 +89,12 @@ Bad::
     var boohoo = false;
 
 
-Semi-colons
+Semicolons
 -----------
 
 **Use them.**
 
-Not because ASI is black-magic, or whatever. I'm sure we all understand ASI.
+Not because ASI is black magic, or whatever. I'm sure we all understand ASI.
 Just do it for consistency.
 
 

--- a/reference/python-style.rst
+++ b/reference/python-style.rst
@@ -7,21 +7,21 @@ know the standards for your project!
 
 General Guidelines
 ------------------
-- Follow PEP8_.
-- Follow Pocoo_'s extensions to PEP8, although these are a little less strictly
+- Follow `PEP 8`_.
+- Follow Pocoo_'s extensions to PEP 8, although these are a little less strictly
   enforced across Mozilla projects.
 - Check your code against a linting tool. flake8_ is highly recommended for
   this.
 
-.. _PEP8: http://www.python.org/dev/peps/pep-0008/
+.. _PEP 8: http://www.python.org/dev/peps/pep-0008/
 .. _flake8: http://flake8.readthedocs.org/en/latest/
 .. _Pocoo: http://www.pocoo.org/internal/styleguide/
 
 Import Statements
 -----------------
 
-We expand on PEP8_'s suggestions for import statements. These greatly improve
-ones ability to ascertain what is and isn't available in a given file.
+We expand on `PEP 8`_'s suggestions for import statements. These greatly improve
+one's ability to ascertain what is and isn't available in a given file.
 
 Import one module per import statement::
 
@@ -32,8 +32,7 @@ not::
 
     import os, sys
 
-Separate imports into groups with a line of whitespace: standard library; Django
-(or framework); third-party; and local imports::
+Separate imports into groups with a line of whitespace: standard library; (if a web app) Django or other framework; third-party; and local imports::
 
     import os
     import sys
@@ -45,7 +44,7 @@ Separate imports into groups with a line of whitespace: standard library; Django
     from myapp import models, views
 
 
-Alphabetize your imports, it will make your code easier to scan. See how
+Alphabetize your imports; it will make your code easier to scan. See how
 terrible this is::
 
     import cows
@@ -58,7 +57,7 @@ A simple sort::
     import cows
     import kittens
 
-Imports on top, ``from``-imports below::
+Imports on top, ``from`` imports below::
 
     import x
     import y
@@ -129,9 +128,9 @@ Use single quotes unless double (or triple) quotes would be an improvement::
 
     '''nobody really does this'''
 
-To continue a new line use a ```()``` not ```\```.
+To continue a new line use a ``()`` not ``\``.
 
-Indenting code should be done in one of two ways: a hanging indent, or 4 space
+Indenting code should be done in one of two ways: a hanging indent, or 4-space
 indent on the next line.
 
 Good, using hanging indent. Note that the next line is lined up with the

--- a/reference/servers.rst
+++ b/reference/servers.rst
@@ -18,7 +18,7 @@ Most Mozilla websites are split into three environments:
 
 - Staging (AKA stage) is intended to be similar to production and is used for
   testing the deployment process itself. Stage is usually deployed before
-  deploying to production, and is sometimes used by QA for testing purposes as
+  production, and it is sometimes used by QA for testing purposes as
   well.
 
   The standard pattern for stage server URLs is ``project.allizom.org``.

--- a/reference/testing.rst
+++ b/reference/testing.rst
@@ -30,14 +30,14 @@ A risk assessment lists out the different parts of your project (such as
 certain webpages or parts of an API) and ranks them based on their importance.
 For example, a news site rank being able to read existing articles as more
 important than being able to submit new articles. Ranking these parts allows
-you to make decisions about which to test more and what kind of tests to run.e
+you to make decisions about which to test more and what kind of tests to run.
 
 Unit and integration tests
 --------------------------
 
 As a developer, the most common type of tests you will write are unit and
 integration tests. Unit tests test the smallest possible chunk of functionality
-and are isolated from eachother. Integration tests test the interaction between
+and are isolated from each other. Integration tests test the interaction between
 these chunks.
 
 In practice, **any changes you make to a project should be tested in some


### PR DESCRIPTION
Good stuff!

I went through most of the manual and fixed mostly grammar and style (e.g. officially it's "GitHub" not "Github", "Git" not "git", etc.).

I also tried rephrasing some things that appeared awkward to me. Feel free to pick and choose the ones you like.

I expanded on a few sections that were overly specific to websites. However, I didn't touch the Security section, which I think needs a bigger overhaul. I'll file a bug for it.
