### PR TITLE
Add commitment curve

### DIFF
--- a/guide/curve.rst
+++ b/guide/curve.rst
@@ -11,7 +11,7 @@ You're just beginning to investigate participation on the A-Team.
 Criteria:
 
 * Find bugs to work on
-* setup irc, bugzilla, hg/git, environment
+* Setup IRC, bugzilla, hg/git, environment
 
 Associate
 ---------
@@ -20,10 +20,10 @@ You're beinning to contribute to the A-Team by getting involved with a project, 
 
 Criteria:
 
-* work with 2+ mozillians
-* 3+ good first bugs
-* 1+ good next bugs
-* get involved in a project
+* Work with 2+ mozillians
+* Resolve 3+ good first bugs
+* Resolve at least 1 mentored bug which isn't a good first bug
+* Get involved in a project
 
 Core Contributor
 ----------------
@@ -32,11 +32,11 @@ You've reached the point where you're a solid and consistent contributor to the 
 
 Criteria:
 
-* mozillians profile
-* 5+ good next bugs
-* participate in meetings
-* file new bugs, review code
-* with with 5+ mozillians
+* Create a Mozillians profile
+* Resolve 5+ good next bugs
+* Participate in meetings
+* File new bugs, review code
+* Work with with 5+ mozillians
 
 Peer
 ----
@@ -45,11 +45,11 @@ You're taking on additional ownership and responsibility within the team.  You'r
 
 Criteria:
 
-* commit access
-* split a project into features/bugs
+* Establish commit access
+* Split a project into features/bugs
 * Propose new features on projects
 * Initiate discussions / meetings
-* mentor new contributors
+* Mentor new contributors
 
 Project Lead
 ------------
@@ -59,6 +59,6 @@ You're a key member of the team, and directly lead one or more projects.  You de
 Criteria:
 
 * Mentor 2+ contributors to be Core Contributors
-* develop and maintain a project
-* participate in all areas of the ateam
+* Develop and maintain a project
+* Participate in all areas of the ateam
 * Solve problems by reusing existing projects

--- a/guide/curve.rst
+++ b/guide/curve.rst
@@ -1,0 +1,64 @@
+Commitment Curve
+================
+
+Contributions on the A-Team, whether paid or volunteer, follow a participation and responsibility trajectory, or commitment curve, described by the stages below.  Each stage, with the exception of Explorer, is associated with a related badge which can be earned by performing all of the tasks listed for each stage.
+
+Explorer
+--------
+
+You're just beginning to investigate participation on the A-Team.
+
+Criteria:
+
+* Find bugs to work on
+* setup irc, bugzilla, hg/git, environment
+
+Associate
+---------
+
+You're beinning to contribute to the A-Team by getting involved with a project, working with some Mozillians, and resolving some bugs.
+
+Criteria:
+
+* work with 2+ mozillians
+* 3+ good first bugs
+* 1+ good next bugs
+* get involved in a project
+
+Core Contributor
+----------------
+
+You've reached the point where you're a solid and consistent contributor to the A-Team.  You regularly participate in team meetings; file, review, and resolve bugs; and expand the number of Mozillians you work with.
+
+Criteria:
+
+* mozillians profile
+* 5+ good next bugs
+* participate in meetings
+* file new bugs, review code
+* with with 5+ mozillians
+
+Peer
+----
+
+You're taking on additional ownership and responsibility within the team.  You're not just fixing bugs, you're helping to direct new contributors and assist with decision-making on projects.
+
+Criteria:
+
+* commit access
+* split a project into features/bugs
+* Propose new features on projects
+* Initiate discussions / meetings
+* mentor new contributors
+
+Project Lead
+------------
+
+You're a key member of the team, and directly lead one or more projects.  You design solutions to problems, accept responsibility for team deliverables, and help other people progress up through the commitment curve.
+
+Criteria:
+
+* Mentor 2+ contributors to be Core Contributors
+* develop and maintain a project
+* participate in all areas of the ateam
+* Solve problems by reusing existing projects

--- a/guide/curve.rst
+++ b/guide/curve.rst
@@ -33,7 +33,7 @@ You've reached the point where you're a solid and consistent contributor to the 
 Criteria:
 
 * Create a Mozillians profile
-* Resolve 5+ good next bugs
+* Resolve 5+ bugs
 * Participate in meetings
 * File new bugs, review code
 * Work with with 5+ mozillians

--- a/guide/index.rst
+++ b/guide/index.rst
@@ -19,3 +19,4 @@ Let's get started!
    software
    projects
    development_process
+   curve


### PR DESCRIPTION
Initial inclusion of commitment curve.  I want to have this included in order to be able to create badges...I need to be able to point those badges at their criteria.

After badges are made, I'll update this with information on how to be nominated for the badges.

@wlach @jmaher please review.
