### PR TITLE
Added beginner git tutorial link to Reference Guide

### DIFF
--- a/reference/git_github.rst
+++ b/reference/git_github.rst
@@ -1,7 +1,11 @@
 Git and GitHub
 ==============
 
-This document describes some best practices for using Git and GitHub.
+If you are a contributor who is completely new to distributed version
+control systems like Git, you might enjoy stepping through some or all
+of this `fun and easy tutorial <https://try.github.io/levels/1/challenges/1>`_.
+
+The sections below describe some A-team best practices for using Git and GitHub.
 
 Commit Messages
 ---------------


### PR DESCRIPTION
This adds a nice interactive Git tutorial at the beginning of the **Reference >> Git and Github** section , so that new contributors who don't have exposure to DVCS will experience Git concepts and basic commands, as part of the A-Team onboarding process.

I didn't build the docs locally, but I mimicked the markup style for the related link, and it works fine on my local Github branch.

I added 'A-team' as a qualifier for the best practices, which while I'm sure they all make total sense, sometimes vary subtly from team to team.

Adding @wlach for review.
