### PR TITLE
Use HTTPS URLs where possible & fix some broken links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 A-team Bootcamp
 ===============
-`View this document at ateam-bootcamp.readthedocs.org
-<http://ateam-bootcamp.readthedocs.org>`_
+`View this document at ateam-bootcamp.readthedocs.io
+<https://ateam-bootcamp.readthedocs.io/>`_
 
 A tutorial on some of the basic things you'd want to know when
 contributing to `Automation & Tools`_ at Mozilla.
@@ -12,7 +12,7 @@ Patches are always welcome! If you'd like to contribute, fork and make a pull
 request.
 
 .. _`Automation & Tools`: https://wiki.mozilla.org/Auto-tools
-.. _`webdev bootcamp`: http://mozweb.readthedocs.org
+.. _`webdev bootcamp`: https://mozweb.readthedocs.io/
 
 Building locally
 ----------------

--- a/conf.py
+++ b/conf.py
@@ -223,5 +223,5 @@ man_pages = [
 ]
 
 intersphinx_mapping = dict(
-    playdoh=('http://playdoh.readthedocs.org/en/latest/', None)
+    playdoh=('https://playdoh.readthedocs.io/en/latest/', None)
     )

--- a/guide/accounts.rst
+++ b/guide/accounts.rst
@@ -22,7 +22,7 @@ for guides on the basics of using Git and GitHub.
       Mozilla's organization account on GitHub.
 
 .. _GitHub: https://github.com/
-.. _Git: http://git-scm.com/
+.. _Git: https://git-scm.com/
 .. _GitHub help site: https://help.github.com/
 
 
@@ -44,8 +44,8 @@ code base, you'll want to apply for `committer access`_ so you can push
 code to try_ or an integration branch like mozilla-inbound.
 
 .. _mozilla-central: https://developer.mozilla.org/en-US/docs/mozilla-central
-.. _Mercurial: http://mercurial.selenic.com
-.. _Mercurial for Mozillians: http://mozilla-version-control-tools.readthedocs.org/en/latest/hgmozilla/
+.. _Mercurial: https://www.mercurial-scm.org/
+.. _Mercurial for Mozillians: https://mozilla-version-control-tools.readthedocs.io/en/latest/hgmozilla/
 .. _`committer access`: https://www.mozilla.org/en-US/about/governance/policies/commit/
 .. _try: https://wiki.mozilla.org/Build:TryServer
 

--- a/guide/development_process.rst
+++ b/guide/development_process.rst
@@ -21,7 +21,7 @@ choice for the project. A well-written bug includes:
 Depending on the project, the bug may be triaged and assigned a priority and/or
 milestone, or it may be added to another system for tracking work, such as Trello_.
 
-.. _Trello: http://trello.com
+.. _Trello: https://trello.com/
 
 Working on the Bug
 ------------------
@@ -98,7 +98,7 @@ process looks like this:
 .. _Mozbase: https://wiki.mozilla.org/Auto-tools/Projects/MozBase
 .. _mozilla-central: https://developer.mozilla.org/en-US/docs/mozilla-central
 .. _mercurial queue: https://developer.mozilla.org/en-US/docs/Mercurial_Queues
-.. _mercurial bookmarks: http://mercurial.selenic.com/wiki/NamedBranches
+.. _mercurial bookmarks: https://www.mercurial-scm.org/wiki/NamedBranches
 .. _submit them as a patch: https://developer.mozilla.org/en-US/docs/Mozilla/Developer_guide/How_to_Submit_a_Patch#Submitting_the_patch
 
 Testing and Resolution

--- a/guide/projects.rst
+++ b/guide/projects.rst
@@ -32,5 +32,5 @@ Once you're set up to work on a project, you'll have to find a task to work on
 and get coding! Each project should have some information on where their tasks
 are tracked, generally on Bugzilla_.
 
-.. _Bugzilla: http://bugzilla.mozilla.org
+.. _Bugzilla: https://bugzilla.mozilla.org
 

--- a/guide/software.rst
+++ b/guide/software.rst
@@ -51,7 +51,7 @@ control systems, you might enjoy stepping through some or all of this
       A Mac OS X program for interacting with GitHub as an alternative to using
       Git in a terminal. Useful if you are not used to using a terminal yet.
 
-.. _Git: http://git-scm.com/
+.. _Git: https://git-scm.com/
 
 Mercurial
 ---------
@@ -66,7 +66,7 @@ automated test infrastructure around it (mochitest, reftest, etc.).
      The MDN page on Mercurial contains some useful links for getting
      started.
 
-.. _Mercurial: http://mercurial.selenic.com
+.. _Mercurial: https://www.mercurial-scm.org/
 
 
 DXR
@@ -78,7 +78,7 @@ projects using the the Mercurial repository.
 - To look up source in Mozilla-Central (trunk) `https://dxr.mozilla.org/mozilla-central/source/`_
 - To look up a specific file in our tree use this url for a base: https://dxr.mozilla.org/mozilla-central/search?q=path%3A and add the file name to it.
 
-Pro tip: You can define a `bookmark keyword in Firefox <http://www.mozilla.org/docs/end-user/keywords.html>`_.
+Pro tip: You can define a `bookmark keyword in Firefox <http://www-archive.mozilla.org/docs/end-user/keywords.html>`_.
 Then you can type "dxrf <filename>" in the URL bar.
 
 
@@ -87,7 +87,7 @@ Pastebin
 
 Pastebin is a tool that can be used to capture snippits of log or error messages for collaborative debugging.
 
-To "pastebin" something, `paste it here <http://pastebin.mozilla.org/>`_ and hand the link you're given after clicking "submit" to people on IRC.
+To "pastebin" something, `paste it here <https://pastebin.mozilla.org/>`_ and hand the link you're given after clicking "submit" to people on IRC.
 
 
 Python

--- a/guide/team.rst
+++ b/guide/team.rst
@@ -3,7 +3,7 @@ About the A-Team
 
 The Engineering Productivity group (called "the A-Team" for nostalgic reasons)
 is a small group dedicated to improving our automation infrastructure and
-tools to better support `Mozilla's automated tests <http://developer.mozilla.org/en/docs/Mozilla_automated_testing overview>`_
+tools to better support `Mozilla's automated tests overview <https://developer.mozilla.org/en/docs/Mozilla/QA/Automated_testing>`_
 and other of Mozilla's Development and Testing efforts.
 
 How to Talk to Us

--- a/index.rst
+++ b/index.rst
@@ -14,7 +14,7 @@ generally useful info, such as style guides, in the :doc:`reference/index`.
 This guide is based off of the excellent `Mozilla WebDev bootcamp`_. It is maintained in a
 `github repository`_. Feel free to send pull requests if you see something that could be improved.
 
-.. _`Mozilla WebDev bootcamp`: https://mozweb.readthedocs.org
+.. _`Mozilla WebDev bootcamp`: https://mozweb.readthedocs.io/
 .. _`github repository`: https://github.com/mozilla/ateam-bootcamp
 
 

--- a/reference/glossary.rst
+++ b/reference/glossary.rst
@@ -10,7 +10,7 @@ define those terms.
    Orange
       An "orange" refers to a test that fails intermittently.  They are called
       "oranges" because they turn our status reporting orange.  View current
-      `list of "oranges" <http://brasstacks.mozilla.com/orangefactor/>`_
+      `list of "oranges" <https://brasstacks.mozilla.com/orangefactor/>`_
 
    pull request
    PR

--- a/reference/js-style.rst
+++ b/reference/js-style.rst
@@ -15,7 +15,7 @@ First and Foremost
    about not knowing what 'require' is. You can add keywords to ignore to a
    `.jshintrc` file.
 
-.. _JSHint: http://www.jshint.com/
+.. _JSHint: http://jshint.com/
 
 
 Variable Formatting:

--- a/reference/python-style.rst
+++ b/reference/python-style.rst
@@ -11,8 +11,8 @@ General Guidelines
 - Check your code against a linting tool. flake8_ is highly recommended for
   this.
 
-.. _PEP 8: http://www.python.org/dev/peps/pep-0008/
-.. _flake8: http://flake8.readthedocs.org/en/latest/
+.. _PEP 8: https://www.python.org/dev/peps/pep-0008/
+.. _flake8: https://flake8.readthedocs.io/
 
 Import Statements
 -----------------

--- a/reference/security.rst
+++ b/reference/security.rst
@@ -5,7 +5,7 @@ This guide will give you a quick heads-up on important security topics to keep
 in mind as you work on projects which face the public internet like Treeherder_.
 
 
-.. _Treeherder: http://treeherder.mozilla.org
+.. _Treeherder: https://treeherder.mozilla.org/
 
 Involving the Security Team
 ---------------------------

--- a/reference/testing.rst
+++ b/reference/testing.rst
@@ -93,7 +93,7 @@ General
   Github.
 - Selenium_ is a tool for automating browsers, often for testing purposes.
 
-.. _Jenkins: http://jenkins-ci.org/
+.. _Jenkins: https://jenkins.io/
 .. _Travis CI: https://travis-ci.org/
 
 Python
@@ -112,10 +112,10 @@ Python
 - Mock_ is one of the most popular libraries for replacing parts of the system
   you're testing with mock objects and asserting things about their behavior.
 
-.. _nose: http://nose.readthedocs.org/en/latest/
+.. _nose: https://nose.readthedocs.io/
 .. _django-nose: https://github.com/django-nose/django-nose
 .. _nose-progressive: https://github.com/erikrose/nose-progressive
-.. _factory-boy: https://factoryboy.readthedocs.org/
+.. _factory-boy: https://factoryboy.readthedocs.io/
 .. _Mock: http://www.voidspace.org.uk/python/mock/
 
 Node / JavaScript


### PR DESCRIPTION
Switches to the HTTPS and/or canonical form of various URLs, and fixes the links to mercurial.selenic.com, since that domain no longer resolves.
